### PR TITLE
don't import Dancer2

### DIFF
--- a/lib/Dancer2/Plugin/Auth/ActiveDirectory.pm
+++ b/lib/Dancer2/Plugin/Auth/ActiveDirectory.pm
@@ -15,7 +15,6 @@ our $VERSION = '0.01';
 use 5.10.0;
 use strict;
 use warnings FATAL => 'all';
-use Dancer2;
 use Dancer2::Plugin;
 use Net::LDAP qw[];
 use Net::LDAP::Constant qw[LDAP_INVALID_CREDENTIALS];


### PR DESCRIPTION
This will not work with latest Dancer2 (0.200000) released today.

I'm not sure what else might cause problems since I do not have AD to test against. If you have problems with new D2 release please get in touch with core devs via IRC (#dancer on freenode) or via the mailing list and we will do our best to help.